### PR TITLE
Better handling of template and asset errors when uploading

### DIFF
--- a/lib/bootic_cli/themes/api_theme.rb
+++ b/lib/bootic_cli/themes/api_theme.rb
@@ -48,6 +48,15 @@ module BooticCli
     end
 
     class APITheme
+
+      class EntityErrors < StandardError
+        attr_reader :errors
+        def initialize(errors)
+          @errors = errors
+          super "Entity has errors: #{errors.map(&:field)}"
+        end
+      end
+
       def initialize(theme)
         @theme = theme
       end
@@ -115,13 +124,6 @@ module BooticCli
       private
       attr_reader :theme
 
-      class EntityErrors < StandardError
-        attr_reader :errors
-        def initialize(errors)
-          @errors = errors
-          super "Entity has errors: #{errors.map(&:field)}"
-        end
-      end
 
       def check_errors!(entity)
         if entity.has?(:errors)

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -334,13 +334,13 @@ module BooticCli
         rescue APITheme::EntityErrors => e
           fields = e.errors.map(&:field)
 
-          error_msg = if fields.include?("file_content_type")
+          error_msg = if fields.include?("file_content_type") or fields.include?("content_type")
             "is an unsupported file type."
           elsif fields.include?("file_file_size") # big asset
             size_str = file.file_size.to_i > 0 ? "(#{file.file_size} KB) " : ''
             "#{size_str}is heavier than the maximum allowed for assets (1 MB)"
           elsif fields.include?("body") # big template
-            str = file.file_name[/\.(css|js)/] ? "Try saving it as an asset instead" : "Try splitting it into smaller chunks"
+            str = file.file_name[/\.(html|liquid)$/] ? "Try splitting it into smaller chunks" : "Try saving it as an asset instead"
             str += ", since templates can hold up to 64 KB of data."
           else
             "has invalid #{fields.join(', ')}"
@@ -350,7 +350,7 @@ module BooticCli
           # abort
 
         rescue JSON::GeneratorError => e
-          prompt.say("#{file.file_name} looks like a binary file. Skipping...", :red)
+          prompt.say("#{file.file_name} looks like a binary file, not a template. Skipping...", :red)
           # abort
 
         rescue BooticClient::ServerError => e

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -335,7 +335,7 @@ module BooticCli
           fields = e.errors.map(&:field)
 
           error_msg = if fields.include?("file_content_type") or fields.include?("content_type")
-            "is an unsupported file type."
+            "is an unsupported file type for #{type}s."
           elsif fields.include?("file_file_size") # big asset
             size_str = file.file_size.to_i > 0 ? "(#{file.file_size} KB) " : ''
             "#{size_str}is heavier than the maximum allowed for assets (1 MB)"


### PR DESCRIPTION
a) Show a clearer message to help devs understand what's going on, and 
b) Don't explode into pieces when that occurs, and simply skip to next asset or template