### PR TITLE
Update IRB init strategy to prevent deadlock errors

### DIFF
--- a/lib/bootic_cli/cli.rb
+++ b/lib/bootic_cli/cli.rb
@@ -162,9 +162,6 @@ module BooticCli
         require 'irb/completion'
         IRB.setup nil
 
-        # IRB.conf[:MAIN_CONTEXT] = IRB::Irb.new.context
-        # require 'irb/ext/multi-irb'
-
         require 'bootic_cli/console'
         context = Console.new(session)
         prompt = "/#{shop.subdomain} (#{root.user_name}|#{root.scopes}) $ "
@@ -182,7 +179,7 @@ module BooticCli
         irb = IRB::Irb.new(IRB::WorkSpace.new(context))
         IRB.conf[:MAIN_CONTEXT] = irb.context
 
-        trap("SIGINT") do
+        trap('SIGINT') do
           irb.signal_handle
         end
 

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -322,6 +322,7 @@ module BooticCli
       end
 
       def upsert_file(theme, path)
+        return if File.basename(path)[0] == '.' # filter out .lock and .state
         item, type = FSTheme.resolve_file(path)
         handle_file_errors(type, item) do
           case type

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -216,8 +216,12 @@ module BooticCli
 
         # ctrl-c
         Signal.trap('INT') {
-          listener.stop
-          puts 'See you in another lifetime, brother.'
+          begin
+            listener.stop
+          rescue ThreadError => e
+            # 
+          end
+          puts "\nSee you in another lifetime, brother."
           exit
         }
 

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -218,8 +218,8 @@ module BooticCli
         Signal.trap('INT') {
           begin
             listener.stop
-          rescue ThreadError => e
-            # 
+          rescue ThreadError => e # cant be called from trap context
+            # nil
           end
           puts "\nSee you in another lifetime, brother."
           exit

--- a/spec/commands/themes_spec.rb
+++ b/spec/commands/themes_spec.rb
@@ -141,7 +141,7 @@ describe BooticCli::Commands::Themes do
 
       expect(shop.themes).not_to receive(:can?)
       expect(shop.themes).not_to receive(:create_dev_theme)
-      expect(prompt).to receive(:say).with("You already have a development theme set up!", :red)
+      expect(prompt).to receive(:say).with("You already have a development theme set up. If you want to delete it, please pass the --delete flag.", :red)
 
       described_class.start(%w(dev))
     end


### PR DESCRIPTION
This is what happens now when you hit Ctrl-C and then Ctrl-D in a x64 Linux computah:

```
$ bootic console
/www4 (tomas|admin,public) $ ^C
/www4 (tomas|admin,public) $ 
/home/tomas/.rbenv/versions/2.4.2/lib/ruby/2.4.0/irb/ext/multi-irb.rb:230:in `stop': No live threads left. Deadlock? (fatal)
1 threads, 1 sleeps current:0x0000557e900da1a0 main thread:0x0000557e900da1a0
* #<Thread:0x0000557e9010de98 sleep_forever>
   rb_thread_t:0x0000557e900da1a0 native:0x00007f4bb0313740 int:0
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/2.4.0/irb/ext/multi-irb.rb:230:in `stop'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/2.4.0/irb/ext/multi-irb.rb:230:in `irb'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bootic_cli-0.6.7/lib/bootic_cli/cli.rb:181:in `block in console'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bootic_cli-0.6.7/lib/bootic_cli/connectivity.rb:33:in `logged_in_action'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bootic_cli-0.6.7/lib/bootic_cli/cli.rb:160:in `console'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
   /home/tomas/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bootic_cli-0.6.7/bin/bootic:4:in `<top (required)>'
   /home/tomas/.rbenv/versions/2.4.2/bin/bootic:23:in `load'
   /home/tomas/.rbenv/versions/2.4.2/bin/bootic:23:in `<main>'
```

This PR changes the current implementation so that we handle SIGINTs gracefully.