### PR TITLE
Retry connection errors during theme sync and keep clone resumable

### DIFF
--- a/lib/bootic_cli/commands/themes.rb
+++ b/lib/bootic_cli/commands/themes.rb
@@ -25,8 +25,18 @@ module BooticCli
             prompt.say "Directory already exists! (#{local_theme.path})", :red
           else
             prompt.say "Cloning theme files into #{local_theme.path}"
-            workflows.pull(local_theme, remote_theme)
+
+            # write the pairing info first, so that if the pull below fails partway
+            # through, the directory is still resumable with `bootic themes pull`
             local_theme.write_subdomain
+
+            begin
+              workflows.pull(local_theme, remote_theme)
+            rescue BooticCli::Themes::Workflows::ConnectionError => e
+              prompt.say e.message, :red
+              prompt.say "Once your connection is back, run `bootic themes pull` from within #{local_theme.path} to finish cloning.", :magenta
+              exit 1
+            end
           end
         end
       end
@@ -273,7 +283,13 @@ module BooticCli
         end
 
         logged_in_action do
-          yield
+          begin
+            yield
+          rescue BooticCli::Themes::Workflows::ConnectionError => e
+            prompt.say e.message, :red
+            prompt.say "Once your connection is back, run `bootic themes pull` from within this directory to resume.", :magenta
+            exit 1
+          end
         end
       end
 

--- a/lib/bootic_cli/commands/themes.rb
+++ b/lib/bootic_cli/commands/themes.rb
@@ -32,7 +32,7 @@ module BooticCli
 
             begin
               workflows.pull(local_theme, remote_theme)
-            rescue BooticCli::Themes::Workflows::ConnectionError => e
+            rescue BooticCli::Themes::Workflows::RetryableError => e
               prompt.say e.message, :red
               prompt.say "Once your connection is back, run `bootic themes pull` from within #{local_theme.path} to finish cloning.", :magenta
               exit 1
@@ -285,7 +285,7 @@ module BooticCli
         logged_in_action do
           begin
             yield
-          rescue BooticCli::Themes::Workflows::ConnectionError => e
+          rescue BooticCli::Themes::Workflows::RetryableError => e
             prompt.say e.message, :red
             prompt.say "Once your connection is back, run `bootic themes pull` from within this directory to resume.", :magenta
             exit 1

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -28,8 +28,12 @@ module BooticCli
       CONCURRENCY = 10
       MAX_ATTEMPTS = 3 # 1 initial try + 2 retries
 
-      # raised when a connection-related error persists after retrying
-      class ConnectionError < StandardError; end
+      # raised when a transient error (network or server-side) persists after retrying
+      class RetryableError < StandardError; end
+      # client couldn't reach the server at all (timeouts, DNS/socket errors)
+      class ConnectionError < RetryableError; end
+      # server responded, but with an error (502s, 503s, etc)
+      class ServerUnavailableError < RetryableError; end
 
       def initialize(prompt: NullPrompt)
         @prompt = prompt
@@ -402,13 +406,21 @@ module BooticCli
           prompt.say("Invalid request: #{e.message}. Skipping...", :red)
           false # just continue, don't abort
 
-        rescue APITheme::UnknownResponse, Faraday::TimeoutError, SocketError, Net::OpenTimeout, Net::ReadTimeout, BooticClient::ServerError => e
+        rescue Faraday::TimeoutError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
           if attempts < MAX_ATTEMPTS
-            prompt.say("Connection trouble while saving #{file.file_name} (#{e.message}). Retrying (attempt #{attempts + 1}/#{MAX_ATTEMPTS})...", :yellow)
+            prompt.say("Trouble connecting to the server while saving #{file.file_name} (#{e.message}). Retrying (attempt #{attempts + 1}/#{MAX_ATTEMPTS})...", :yellow)
             retry
           end
 
           raise ConnectionError, "Couldn't reach the server to save #{file.file_name} after #{attempts} attempts (#{e.message})."
+
+        rescue APITheme::UnknownResponse, BooticClient::ServerError => e # 502s, 503s, etc
+          if attempts < MAX_ATTEMPTS
+            prompt.say("Server error while saving #{file.file_name} (#{e.message}). Retrying (attempt #{attempts + 1}/#{MAX_ATTEMPTS})...", :yellow)
+            retry
+          end
+
+          raise ServerUnavailableError, "Server kept failing to save #{file.file_name} after #{attempts} attempts (#{e.message})."
         end
       end
     end

--- a/lib/bootic_cli/themes/workflows.rb
+++ b/lib/bootic_cli/themes/workflows.rb
@@ -26,6 +26,10 @@ module BooticCli
 
     class Workflows
       CONCURRENCY = 10
+      MAX_ATTEMPTS = 3 # 1 initial try + 2 retries
+
+      # raised when a connection-related error persists after retrying
+      class ConnectionError < StandardError; end
 
       def initialize(prompt: NullPrompt)
         @prompt = prompt
@@ -362,7 +366,9 @@ module BooticCli
       end
 
       def handle_file_errors(type, file, &block)
+        attempts = 0
         begin
+          attempts += 1
           yield
           true
         rescue APITheme::EntityErrors => e
@@ -396,17 +402,13 @@ module BooticCli
           prompt.say("Invalid request: #{e.message}. Skipping...", :red)
           false # just continue, don't abort
 
-        rescue APITheme::UnknownResponse => e # 502s, 503s, etc
-          prompt.say("Got an unknown response from server: #{e.message}. Please try again in a minute.", :red)
-          exit
+        rescue APITheme::UnknownResponse, Faraday::TimeoutError, SocketError, Net::OpenTimeout, Net::ReadTimeout, BooticClient::ServerError => e
+          if attempts < MAX_ATTEMPTS
+            prompt.say("Connection trouble while saving #{file.file_name} (#{e.message}). Retrying (attempt #{attempts + 1}/#{MAX_ATTEMPTS})...", :yellow)
+            retry
+          end
 
-        rescue Faraday::TimeoutError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-          prompt.say("I'm having trouble connecting to the server. Please try again in a minute.", :red)
-          exit
-
-        rescue BooticClient::ServerError => e
-          prompt.say("Couldn't save #{file.file_name}. Please try again in a few minutes.", :red)
-          exit
+          raise ConnectionError, "Couldn't reach the server to save #{file.file_name} after #{attempts} attempts (#{e.message})."
         end
       end
     end


### PR DESCRIPTION
Write the .state pairing file before pulling in `clone`, so a failed pull leaves a directory that `bootic themes pull` can resume instead of one stuck in an unrecoverable state. Also retry connection-related failures (timeouts, socket errors, 5xx) up to twice before giving up, and point the user to `bootic themes pull` when retries are exhausted.