### PR TITLE
Recognize .md files in theme roots as templates

### DIFF
--- a/lib/bootic_cli/themes/fs_theme.rb
+++ b/lib/bootic_cli/themes/fs_theme.rb
@@ -31,13 +31,13 @@ module BooticCli
 
       ASSETS_DIR = 'assets'.freeze
       TEMPLATE_PATTERNS = [
-        '*.html', '*.css', '*.js', '*.json', '*.yml',
+        '*.html', '*.css', '*.js', '*.json', '*.yml', '*.md',
         'sections/*.html', 'partials/*.html', 'data/*.json', 'data/*.yml'
       ].freeze
       ASSET_PATTERNS = [File.join(ASSETS_DIR, '*')].freeze
 
       ASSET_PATH_REGEX = /^assets\/[^\/]+$/.freeze
-      TEMPLATE_PATH_REGEX = /^[^\/]+\.(html|css|scss|js|json|yml)$/.freeze
+      TEMPLATE_PATH_REGEX = /^[^\/]+\.(html|css|scss|js|json|yml|md)$/.freeze
       SECTION_PATH_REGEX = /^(sections|partials)\/[^\/]+\.html$/.freeze
       DATA_PATH_REGEX = /^data\/[^\/]+\.(json|yml)$/.freeze
 

--- a/spec/fixtures/theme/readme.md
+++ b/spec/fixtures/theme/readme.md
@@ -1,0 +1,3 @@
+# Theme readme
+
+Some notes about this theme.

--- a/spec/themes/fs_theme_spec.rb
+++ b/spec/themes/fs_theme_spec.rb
@@ -30,12 +30,13 @@ describe BooticCli::Themes::FSTheme do
     expect(subject.assets.size).to eq 1
     it_is_an_asset(subject.assets.first, file_name: 'script.js')
 
-    expect(subject.templates.size).to eq 5
+    expect(subject.templates.size).to eq 6
     it_is_a_template(subject.templates[0], file_name: 'layout.html')
     it_is_a_template(subject.templates[1], file_name: 'master.css')
     it_is_a_template(subject.templates[2], file_name: 'strings.en.json')
-    it_is_a_template(subject.templates[3], file_name: 'sections/gallery.html')
-    it_is_a_template(subject.templates[4], file_name: 'data/test.json')
+    it_is_a_template(subject.templates[3], file_name: 'readme.md')
+    it_is_a_template(subject.templates[4], file_name: 'sections/gallery.html')
+    it_is_a_template(subject.templates[5], file_name: 'data/test.json')
   end
 
   it "#add_template" do
@@ -44,19 +45,29 @@ describe BooticCli::Themes::FSTheme do
     file = File.new('./spec/fixtures/theme/foo.html')
     expect(file.read).to eq 'Hello!'
 
-    expect(subject.templates.size).to eq 6
-    expect(subject.templates.map(&:file_name).sort).to eq ['data/test.json', 'foo.html', 'layout.html', 'master.css', 'sections/gallery.html', 'strings.en.json']
+    expect(subject.templates.size).to eq 7
+    expect(subject.templates.map(&:file_name).sort).to eq ['data/test.json', 'foo.html', 'layout.html', 'master.css', 'readme.md', 'sections/gallery.html', 'strings.en.json']
     tpl = subject.templates.find{|t| t.file_name == 'foo.html' }
     expect(tpl.updated_on).to eq file.mtime.utc
 
     subject.remove_template 'foo.html'
   end
 
+  it "recognizes .md files at the theme root as templates" do
+    subject.add_template 'CHANGELOG.md', '# Changes'
+
+    tpl = subject.templates.find { |t| t.file_name == 'CHANGELOG.md' }
+    expect(tpl).not_to be_nil
+    expect(tpl.body).to eq '# Changes'
+
+    subject.remove_template 'CHANGELOG.md'
+  end
+
   it "#remove_template" do
     subject.add_template 'foo.html', 'Hello!'
     subject.remove_template 'foo.html'
 
-    expect(subject.templates.size).to eq 5
+    expect(subject.templates.size).to eq 6
     expect(File.exist?('./spec/fixtures/theme/foo.html')).to be false
   end
 


### PR DESCRIPTION
## Summary
- The API recently added support for `.md` files at the theme root, alongside `.json`/`.yml`.
- `FSTheme` classified root files by extension via `TEMPLATE_PATTERNS`/`TEMPLATE_PATH_REGEX`, which didn't include `.md`, so local `.md` files at a theme root were silently ignored by `pull`/`push`/`sync`/`watch`.
- Added `.md` to both the glob patterns and the path regex used for classification.

## Test plan
- [x] `bundle exec rspec spec/themes/fs_theme_spec.rb` — added a fixture `readme.md` and a dedicated test asserting `.md` root files are recognized as templates.
- [x] `bundle exec rspec spec/themes/{fs_theme,mem_theme,missing_items_theme,updated_theme}_spec.rb` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)